### PR TITLE
#5: add LanguageTool workflow

### DIFF
--- a/.github/workflows/languagetool.yml
+++ b/.github/workflows/languagetool.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: languagetool
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  languagetool:
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: reviewdog/action-languagetool@v1.23.0
+        with:
+          patterns: README.txt
+          language: en-US
+          disabled_categories: TYPOS,TYPOGRAPHY
+          disabled_rules: WHITESPACE_RULE,EN_QUOTES,DASH_RULE,WORD_CONTAINS_UNDERSCORE,UPPERCASE_SENTENCE_START,ARROWS,COMMA_PARENTHESIS_WHITESPACE,UNLIKELY_OPENING_PUNCTUATION,SENTENCE_WHITESPACE,CURRENCY,EN_UNPAIRED_BRACKETS,PHRASE_REPETITION,PUNCTUATION_PARAGRAPH_END,METRIC_UNITS_EN_US,ENGLISH_WORD_REPEAT_BEGINNING_RULE,EN_COMPOUNDS_FAIL_SAFE,HYPHEN_TO_EN


### PR DESCRIPTION
Closes #5.

Summary:
- Add a LanguageTool workflow for `README.txt`.
- Keep the existing `typos` workflow responsible for spelling by disabling LanguageTool typo and typography categories.
- Disable the two current intentional style hits so the current prompt text stays clean while grammar checks run.

Validation:
- `typos README.txt .github/workflows/*.yml renovate.json REUSE.toml LICENSE.txt` -> passed.
- `bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) latest "$tmp" ... && "$tmp/actionlint" -color=false` -> passed.
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }; puts "ok"' .github/workflows/*.yml` -> `ok`.
- `yamllint .github/workflows/languagetool.yml` in a temporary Python venv -> passed.
- `reuse lint` in a temporary Python venv -> compliant with REUSE 3.3.
- LanguageTool API check on `README.txt` with the workflow categories/rules -> zero matches.
- `git diff HEAD~1 HEAD --check` -> passed.
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.

Limitation: I could not run the Docker-based GitHub Action locally because this host has no Docker and no Java runtime.
